### PR TITLE
fix the snippet while using 'gui' with 'electron'

### DIFF
--- a/docs/guides/js/getting_started.md
+++ b/docs/guides/js/getting_started.md
@@ -76,7 +76,7 @@ const electron = require('electron')
 const gui = require('gui')
 
 const win = gui.Window.create({})
-win.onClose = () => gui.lifetime.quit()
+win.onClose = () => electron.app.quit()
 win.setContentView(gui.Label.create('Content View'))
 win.setContentSize({width: 400, height: 400})
 win.center()


### PR DESCRIPTION
According to the line https://github.com/yue/yue/blob/master/node_yue/binding_gui.cc#L152, it seems there's no `lifetime` object when we build the module using `electron-rebuild`.

Thus, I replace the `gui.lifetime.quit` method with the `electron.app.quit` method, which should make sense now. 😄 