### PR TITLE
Don't return (-1, -1) in getSelectionRange

### DIFF
--- a/docs/api/textedit.yaml
+++ b/docs/api/textedit.yaml
@@ -59,7 +59,7 @@ methods:
     description: |
       Return the start position and end position of current selection.
 
-      If nothing is selected, (-1, -1) would be returned.
+      If nothing is selected, the cursor position will be returned as both values, ie. (0, 0).
 
   - signature: void SelectRange(int start, int end)
     description: Select text between `start` and `end` positions.

--- a/nativeui/gtk/text_edit_gtk.cc
+++ b/nativeui/gtk/text_edit_gtk.cc
@@ -126,11 +126,13 @@ std::tuple<int, int> TextEdit::GetSelectionRange() const {
   GtkTextBuffer* buffer = gtk_text_view_get_buffer(
       GTK_TEXT_VIEW(g_object_get_data(G_OBJECT(GetNative()), "text-view")));
   GtkTextIter start_iter, end_iter;
+  gint pos;
   if (gtk_text_buffer_get_selection_bounds(buffer, &start_iter, &end_iter)) {
     return std::make_tuple(gtk_text_iter_get_offset(&start_iter),
                            gtk_text_iter_get_offset(&end_iter));
   } else {
-    return std::make_tuple(-1, -1);
+    g_object_get(buffer, "cursor-position", &pos, NULL);
+    return std::make_tuple(pos, pos);
   }
 }
 

--- a/nativeui/mac/text_edit_mac.mm
+++ b/nativeui/mac/text_edit_mac.mm
@@ -171,12 +171,8 @@ std::tuple<int, int> TextEdit::GetSelectionRange() const {
   auto* textView = static_cast<NSTextView*>(
       [static_cast<NUTextEdit*>(GetNative()) documentView]);
   NSRange range = [textView selectedRange];
-  if (range.length > 0) {
-    return std::make_tuple<int, int>(
-        range.location, range.location + range.length);
-  } else {
-    return std::make_tuple(-1, -1);
-  }
+  return std::make_tuple<int, int>(
+      range.location, range.location + range.length);
 }
 
 void TextEdit::SelectRange(int start, int end) {

--- a/nativeui/text_edit_unittests.cc
+++ b/nativeui/text_edit_unittests.cc
@@ -32,7 +32,7 @@ TEST_F(TextEditTest, SetText) {
 
 TEST_F(TextEditTest, EmptySelection) {
   edit_->SetText("test");
-  EXPECT_EQ(edit_->GetSelectionRange(), std::make_tuple(-1, -1));
+  EXPECT_EQ(edit_->GetSelectionRange(), std::make_tuple(4, 4));
 }
 
 TEST_F(TextEditTest, SelectRange) {

--- a/nativeui/text_edit_unittests.cc
+++ b/nativeui/text_edit_unittests.cc
@@ -49,6 +49,7 @@ TEST_F(TextEditTest, InsertText) {
   EXPECT_EQ(edit_->GetText(), "abd");
   edit_->InsertTextAt("c", 2);
   EXPECT_EQ(edit_->GetText(), "abcd");
+  EXPECT_EQ(edit_->GetSelectionRange(), std::make_tuple(3, 3));
 }
 
 TEST_F(TextEditTest, Clipboard) {

--- a/nativeui/win/text_edit_win.cc
+++ b/nativeui/win/text_edit_win.cc
@@ -130,10 +130,7 @@ std::tuple<int, int> TextEdit::GetSelectionRange() const {
   int start, end;
   ::SendMessage(hwnd, EM_GETSEL, reinterpret_cast<WPARAM>(&start),
                                  reinterpret_cast<LPARAM>(&end));
-  if (start == end)
-    return std::make_tuple(-1, -1);
-  else
-    return std::make_tuple(start, end);
+  return std::make_tuple(start, end);
 }
 
 void TextEdit::SelectRange(int start, int end) {

--- a/nativeui/win/text_edit_win.cc
+++ b/nativeui/win/text_edit_win.cc
@@ -87,6 +87,8 @@ TextEdit::~TextEdit() {
 
 void TextEdit::SetText(const std::string& text) {
   static_cast<EditView*>(GetNative())->SetText(text);
+  int len = text.length();
+  SelectRange(len, len);
 }
 
 std::string TextEdit::GetText() const {


### PR DESCRIPTION
When no text is selected, `getSelectionRange` should return the caret position. Returning `[-1, -1]` is very strange behavior.