### PR TITLE
Support associated application files

### DIFF
--- a/docs/api/lifetime.yaml
+++ b/docs/api/lifetime.yaml
@@ -23,6 +23,14 @@ events:
     description: |
       Emitted when received `applicationDidFinishLaunching` notification.
 
+  - callback: void on_open(std::string fileURLPath)
+    platform: ['macOS']
+    description: |
+      Emitted when received `applicationWillUpdate`. Emitted with a url string
+      containing `file:///absolute/path/to/file` for each file that you `open
+      with` using a program. Will be emitted multiple times through the lifetime
+      of the program as files are opened during program run.
+
   - callback: void on_activate()
     platform: ['macOS']
     description: |

--- a/lua_yue/binding_gui.cc
+++ b/lua_yue/binding_gui.cc
@@ -182,6 +182,7 @@ struct Type<nu::Lifetime> {
 #if defined(OS_MACOSX)
     RawSetProperty(state, index,
                    "onready", &nu::Lifetime::on_ready,
+                   "onopen", &nu::Lifetime::on_open,
                    "onactivate", &nu::Lifetime::on_activate);
 #endif
   }

--- a/nativeui/lifetime.h
+++ b/nativeui/lifetime.h
@@ -5,6 +5,7 @@
 #ifndef NATIVEUI_LIFETIME_H_
 #define NATIVEUI_LIFETIME_H_
 
+#include <string>
 #include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "nativeui/signal.h"
@@ -32,6 +33,7 @@ class NATIVEUI_EXPORT Lifetime {
   // Events.
 #if defined(OS_MACOSX)
   Signal<void()> on_ready;
+  Signal<void(const std::string&)> on_open;
   Signal<void()> on_activate;
 #endif
 

--- a/nativeui/mac/nu_application_delegate.h
+++ b/nativeui/mac/nu_application_delegate.h
@@ -14,6 +14,8 @@ class Lifetime;
 @interface NUApplicationDelegate : NSObject<NSApplicationDelegate> {
  @private
   nu::Lifetime* shell_;
+ @private
+  NSMutableArray *fileURLPaths;
 }
 - (id)initWithShell:(nu::Lifetime*)shell;
 @end

--- a/nativeui/mac/nu_application_delegate.mm
+++ b/nativeui/mac/nu_application_delegate.mm
@@ -11,10 +11,44 @@
 - (id)initWithShell:(nu::Lifetime*)shell {
   if ((self = [super init]))
     shell_ = shell;
+    // Array of file:// urls which may have opened program by open with
+    fileURLPaths = [[NSMutableArray alloc]init];
   return self;
 }
 
+// Gets sent an event every time a file is opened on mac (file://)
+- (void)getURL:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)reply {
+  // Convert file handle open request from event to NSString
+  NSString* fileURLPath = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+  // Write a recvd file handle open request to an array
+  [fileURLPaths addObject:fileURLPath];
+}
+
+// Called late enough that all file open events from initial launch can be sent
+- (void)applicationWillUpdate:(NSNotification *)notification {
+  // Determine amount of fileURLPaths
+  NSUInteger totalPaths = [fileURLPaths count];
+  // If any fileURLPaths were recvd
+  if (totalPaths > 0) {
+    // Get last index of fileURLPaths NSMutableArray
+    NSUInteger lastIdx = totalPaths - 1;
+    // Iterate over file:// open urls while it has path items
+    do {
+      // Send file:// open url via lifetime.on_open signal
+      shell_->on_open.Emit(std::string([fileURLPaths[lastIdx] UTF8String]));
+      // Clear file:// open url from the array
+      [fileURLPaths removeObjectAtIndex:lastIdx];
+      // Decrement last index
+      lastIdx--;
+    } while (lastIdx != 0);
+  }
+}
+
 - (void)applicationWillFinishLaunching:(NSNotification*)notify {
+  // Ask for an event to be sent to getURL when file is opened with our program
+  [[NSAppleEventManager sharedAppleEventManager]
+    setEventHandler:self andSelector:@selector(getURL:withReplyEvent:)
+    forEventClass:kInternetEventClass andEventID:kAEGetURL];
   // Don't add the "Enter Full Screen" menu item automatically.
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
 }

--- a/node_yue/binding_gui.cc
+++ b/node_yue/binding_gui.cc
@@ -194,6 +194,7 @@ struct Type<nu::Lifetime> {
 #if defined(OS_MACOSX)
     SetProperty(context, templ,
                 "onReady", &nu::Lifetime::on_ready,
+                "onOpen", &nu::Lifetime::on_open,
                 "onActivate", &nu::Lifetime::on_activate);
 #endif
   }


### PR DESCRIPTION
Review requested [not merge ready]

Currently when you create an application that needs support for file:// url scheme handling (Triggered if a .html file is opened with your program on macos) you cannot get these events. You are able to get them by asking for the apple event manager to send them to a method you implement on the mac delegate.

To support this a method was added to the mac application delegate that takes this url event and sends the contained file:// url string as a signal to the lifetime on_open method. This is provided to the application after it activates since events can happen before the shell_ is ready.

Here is an example plist entry which adds file:// scheme support to a built application.
```
...
  <key>CFBundleURLTypes</key>
  <array>
    <dict>
      <key>CFBundleURLName</key>
      <string>file URL</string>
      <key>CFBundleURLSchemes</key>
      <array>
	<string>file</string>
      </array>
    </dict>
  </array>
...
```
More information on `CFBundleURLTypes` can be found here:
  - https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102207

The current approach requires a long lived Mutable array containing strings which is not ideal since it may lead down the path of doing the same for other events that are fired and need to be emitted once the program is ready.

A more flexible and less overhead approach may be to suspend each event and store the suspension id inside of a mutable array. Once the application is ready to capture signals the program could ask the event manager to send the events again and then emit them as signals right away. 

More information on `Suspending and Resuming Apple Events` can be found here:
 - https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ScriptableCocoaApplications/SApps_handle_AEs/SAppsHandleAEs.html#//apple_ref/doc/uid/20001239-BBCIJGHC