### PR TITLE
Enable items to be added to mac toolbar

### DIFF
--- a/lua_yue/binding_gui.cc
+++ b/lua_yue/binding_gui.cc
@@ -925,6 +925,7 @@ struct Type<nu::Toolbar> {
            "setalloweditemidentifiers", &nu::Toolbar::SetAllowedItemIdentifiers,
            "setallowcustomization", &nu::Toolbar::SetAllowCustomization,
            "setdisplaymode", &nu::Toolbar::SetDisplayMode,
+           "setitems", &nu::Toolbar::SetItems,
            "setvisible", &nu::Toolbar::SetVisible,
            "isvisible", &nu::Toolbar::IsVisible,
            "getidentifier", &nu::Toolbar::GetIdentifier);

--- a/nativeui/mac/toolbar_mac.mm
+++ b/nativeui/mac/toolbar_mac.mm
@@ -184,6 +184,10 @@ void Toolbar::SetDisplayMode(DisplayMode mode) {
   toolbar_.displayMode = static_cast<NSToolbarDisplayMode>(mode);
 }
 
+void Toolbar::SetItems(std::vector<Item> items) {
+  toolbar_.items = static_cast<NSArray<NSToolbarItem>>(items);
+}
+
 void Toolbar::SetVisible(bool visible) {
   toolbar_.visible = visible;
 }

--- a/nativeui/toolbar.h
+++ b/nativeui/toolbar.h
@@ -52,6 +52,7 @@ class NATIVEUI_EXPORT Toolbar : public base::RefCounted<Toolbar> {
   void SetAllowedItemIdentifiers(const std::vector<std::string>& identifiers);
   void SetAllowCustomization(bool allow);
   void SetDisplayMode(DisplayMode mode);
+  void SetItems(std::vector<Item> items);
   void SetVisible(bool visible);
   bool IsVisible() const;
   std::string GetIdentifier() const;

--- a/node_yue/binding_gui.cc
+++ b/node_yue/binding_gui.cc
@@ -1048,6 +1048,7 @@ struct Type<nu::Toolbar> {
         "setAllowedItemIdentifiers", &nu::Toolbar::SetAllowedItemIdentifiers,
         "setAllowCustomization", &nu::Toolbar::SetAllowCustomization,
         "setDisplayMode", &nu::Toolbar::SetDisplayMode,
+        "setItems", &nu::Toolbar::SetItems,
         "setVisible", &nu::Toolbar::SetVisible,
         "isVisible", &nu::Toolbar::IsVisible,
         "getIdentifier", &nu::Toolbar::GetIdentifier);


### PR DESCRIPTION
Not in a working state [review needed]

I wasn't able to see a way to add items to the mac osx toolbar. 
There doesn't seem to be code that would allow items to be set on the toolbar as per the documentation.
 - https://developer.apple.com/documentation/appkit/nstoolbaridentifier?language=objc
 - https://developer.apple.com/documentation/appkit/nstoolbar/1516946-items?language=objc

I am unfamiliar with this api and would also need some help getting this to a working state if this approach is heading down the correct path. 

This addresses issue #55 