### PR TITLE
in lua bindings merge RawSetProperty calls in nu::NotificationCenter::BuildMetaTable as RawSetProperty drops any previously registered properties

### DIFF
--- a/lua_yue/binding_gui.cc
+++ b/lua_yue/binding_gui.cc
@@ -1517,6 +1517,14 @@ struct Type<nu::NotificationCenter> {
            &nu::NotificationCenter::GetToastActivatorCLSID);
 #endif
     RawSetProperty(state, metatable,
+#if defined(OS_MAC) || defined(OS_WIN)
+                   "onnotificationreply",
+                   &nu::NotificationCenter::on_notification_reply,
+#endif
+#if defined(OS_WIN)
+                   "ontoastactivate",
+                   &nu::NotificationCenter::on_toast_activate,
+#endif
                    "onnotificationshow",
                    &nu::NotificationCenter::on_notification_show,
                    "onnotificationclose",
@@ -1525,16 +1533,6 @@ struct Type<nu::NotificationCenter> {
                    &nu::NotificationCenter::on_notification_click,
                    "onnotificationaction",
                    &nu::NotificationCenter::on_notification_action);
-#if defined(OS_MAC) || defined(OS_WIN)
-    RawSetProperty(state, metatable,
-                   "onnotificationreply",
-                   &nu::NotificationCenter::on_notification_reply);
-#endif
-#if defined(OS_WIN)
-    RawSetProperty(state, metatable,
-                   "ontoastactivate",
-                   &nu::NotificationCenter::on_toast_activate);
-#endif
   }
 };
 


### PR DESCRIPTION
fixes issue #135

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/yue/yue/tree/5079c44#contributor-license-agreement) of this project .
