### PR TITLE
docs: update windows SDK requirement

### DIFF
--- a/docs/development/build_instructions.md
+++ b/docs/development/build_instructions.md
@@ -18,7 +18,7 @@ build scripts before actually building Yue.
 
 * Visual Studio 2022
   * "Desktop development with C++" component
-  * Latest Windows 10 SDK
+  * [Windows 11 SDK (10.0.22621.0)](https://go.microsoft.com/fwlink/?linkid=2237387)
 
 ### Linux
 


### PR DESCRIPTION
`building\tools\gn\build\vs_toolchain.py` line 41 said Windows SDK should be `10.0.22621.0`

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/yue/yue/tree/5079c44#contributor-license-agreement) of this project .
